### PR TITLE
✨ Add RHEED image file name and improve data loading system (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+<a name="2.0.0"></a>
+## [2.0.0] – 2025-xx-xx
+
+- Organize and simplify the data loading logic
+- Breaking change: remove: `load_data_manual()`, now only load_data() is available 
+and works as manual when no plugin is provided
+- Add file name and file creation time to loaded image in attrs
+- Update the documentation
+
+
 <a name="1.3.4"></a>
 ## [1.3.4] – 2025-09-30
 

--- a/docs/source/loaders.rst
+++ b/docs/source/loaders.rst
@@ -4,12 +4,12 @@ Data Loading
 Using Plugins
 -------------
 
-xRHEED uses a plugin system to load RHEED images and provide geometry information for each experiment.
+xRHEED uses a flexible plugin system to load RHEED images and provide geometry information for each experiment.
 
 A plugin should:
 
-- **Load a particular data format** (e.g., ``.raw``, ``.png``, ``.bmp``).  
-- **Include RHEED geometry** by defining an ``ATTRS`` dictionary with keys such as:
+- **Load a specific data format** (e.g., ``.raw``, ``.png``, ``.bmp``).  
+- **Provide RHEED geometry** by defining an ``ATTRS`` dictionary with keys such as:
 
   - ``plugin``: Name of the plugin.  
   - ``screen_sample_distance``: Distance from sample to screen (in mm).  
@@ -23,7 +23,7 @@ A plugin should:
 
 - **Return an ``xarray.DataArray``** with:
   - ``sx`` (horizontal) and ``sy`` (vertical) coordinates, both in millimeters.  
-  - Coordinates sorted so that the image is oriented with the shadow edge at the top (i.e., the image is "facing down").  
+  - Coordinates sorted so the image is oriented with the shadow edge at the top (i.e., the image is "facing down").  
   - The ``sy`` values covering the image should be negative at the top of the image.
 
 Example plugin attributes:
@@ -41,14 +41,15 @@ Example plugin attributes:
         "beta": 2.0,   # default incident angle
     }
 
-
+.. note::
+     There is a helper function `dataarray_from_image()` that might be used to create DataArray from a numpy image, using ATTRS scaling and centers. Plugins may use or override this.
 
 Manual
 ------
 
-While writing and using a dedicated plugin is the recommended approach, it is also possible to load RHEED images manually (BMP, PNG, TIFF, or other formats) using the ``load_data_manual()`` function.
+While writing and using a dedicated plugin is the recommended approach, you can also load RHEED images manually (BMP, PNG, TIFF, or other formats) using the same ``load_data()`` function, but without providing `plugin`.
 
-In this mode, the user must provide the essential calibration parameters directly:
+In this mode, you must provide the essential calibration parameters directly as keyword arguments:
 
 - ``screen_sample_distance``: Distance from sample to screen [mm].  
 - ``screen_scale``: Pixel-to-mm scaling factor.
@@ -63,7 +64,7 @@ Example usage:
 
     import xrheed
 
-    rheed_image = xrheed.load_data_manual(
+    rheed_image = xrheed.load_data(
         "example.bmp",
         screen_sample_distance=309.2,
         screen_scale=9.04,

--- a/docs/source/notebooks/getting_started.ipynb
+++ b/docs/source/notebooks/getting_started.ipynb
@@ -70,7 +70,7 @@
     "While writing and using a dedicated plugin is the recommended approach, it is also possible to load RHEED images manually (from **BMP**, **PNG**, **TIFF**, or other supported image formats).  \n",
     "In this mode, you must provide the necessary calibration parameters directly.  \n",
     "\n",
-    "Use the `load_data_manual()` function as shown below.  \n",
+    "Use the `load_data()` function as shown below.  \n",
     "At minimum, the following three parameters are required:\n",
     "\n",
     "- **`screen_sample_distance`** *(float)* — Distance from sample to screen [mm].  \n",
@@ -88,11 +88,11 @@
     "image_dir = Path(\"example_data\")\n",
     "image_path = image_dir / \"test_rheed.BMP\"\n",
     "\n",
-    "rheed_manual = xrheed.load_data_manual(\n",
+    "rheed_manual = xrheed.load_data(\n",
     "    image_path,\n",
     "    screen_sample_distance=350.5,\n",
     "    screen_scale=9.5,\n",
-    "    beam_energy=18600,\n",
+    "    beam_energy=18_600,\n",
     "    screen_center_sx_px=749,\n",
     "    screen_center_sy_px=82,\n",
     ")"
@@ -146,6 +146,42 @@
    "id": "11",
    "metadata": {},
    "source": [
+    "Return a human-readable summary of the DataArray and key RHEED metadata."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rheed_image.ri"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "To view all metadata associated with the image, simply access the `.attrs` property of the `DataArray` object. This will display a dictionary of all attributes stored with the image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rheed_image.attrs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15",
+   "metadata": {},
+   "source": [
     "## RHEED Image Data Preparation\n",
     "\n",
     "### Setting the Image Center\n",
@@ -167,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,7 +220,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "17",
    "metadata": {},
    "source": [
     "If the position looks correct, we then apply the values using the `apply_image_center` method available through the `.ri` accessor.\n",
@@ -195,7 +231,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -207,7 +243,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "19",
    "metadata": {},
    "source": [
     "### Automated Center Search\n",
@@ -224,7 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,7 +283,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "21",
    "metadata": {},
    "source": [
     "Alternatively, both functions can be called automatically using the same `apply_image_center` method with the `auto_center=True` attribute.\n",
@@ -259,7 +295,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -273,7 +309,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "23",
    "metadata": {},
    "source": [
     "### Setting the Incident Angle\n",
@@ -292,7 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,7 +339,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "25",
    "metadata": {},
    "source": [
     "To update the image attribute with the real incident angle β, you can use the `.ri` accessor:"
@@ -312,7 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,7 +358,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "27",
    "metadata": {},
    "source": [
     "## Image Rotation\n",
@@ -333,7 +369,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -355,7 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -368,7 +404,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "30",
    "metadata": {},
    "source": [
     "## Screen ROI\n",
@@ -381,7 +417,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -396,7 +432,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "32",
    "metadata": {},
    "source": [
     "## High-Pass Filter\n",
@@ -416,7 +452,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/src/xrheed/__init__.py
+++ b/src/xrheed/__init__.py
@@ -7,13 +7,13 @@ import logging
 import pkgutil
 from importlib.metadata import PackageNotFoundError, version
 
-# Import xarray accessors
-from . import xarray_accessors  # noqa: F401
-from .loaders import load_data, load_data_manual
+# Expose top-level API
+from . import xarray_accessors  # noqa: F401 (registers accessors)
+from .loaders import load_data
 
-__all__ = ["load_data", "load_data_manual", "__version__"]
+__all__ = ["load_data", "__version__"]
 
-# Package version
+# Package version (from setuptools_scm if installed, otherwise fallback)
 try:
     __version__ = version("xrheed")
 except PackageNotFoundError:
@@ -21,27 +21,9 @@ except PackageNotFoundError:
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.info(f"xrheed {__version__} initialized successfully. Accessors registered.")
 
-
-# Check if running inside a Jupyter notebook
-def _in_jupyter():
-    try:
-        from IPython import get_ipython
-
-        shell = get_ipython()
-        return shell is not None and shell.__class__.__name__ == "ZMQInteractiveShell"
-    except Exception:
-        return False
-
-
-# Show a welcome message in Jupyter
-if _in_jupyter():
-    print(f"\n🎉 xrheed v{__version__} loaded!")
-
-
-# Plugin discovery
-def discover_plugins():
+# Auto-discover plugins
+def _discover_plugins():
     try:
         import xrheed.plugins
 
@@ -51,6 +33,16 @@ def discover_plugins():
     except Exception as e:
         logger.warning(f"Plugin discovery failed: {e}")
 
+_discover_plugins()
 
-# Run plugin discovery after all imports
-discover_plugins()
+# Optional: friendly message in notebooks
+def _in_jupyter() -> bool:
+    try:
+        from IPython import get_ipython
+        shell = get_ipython()
+        return shell is not None and shell.__class__.__name__ == "ZMQInteractiveShell"
+    except Exception:
+        return False
+
+if _in_jupyter():
+    print(f"\n🎉 xrheed v{__version__} loaded!")

--- a/src/xrheed/__init__.py
+++ b/src/xrheed/__init__.py
@@ -22,6 +22,7 @@ except PackageNotFoundError:
 # Configure logging
 logger = logging.getLogger(__name__)
 
+
 # Auto-discover plugins
 def _discover_plugins():
     try:
@@ -33,16 +34,20 @@ def _discover_plugins():
     except Exception as e:
         logger.warning(f"Plugin discovery failed: {e}")
 
+
 _discover_plugins()
+
 
 # Optional: friendly message in notebooks
 def _in_jupyter() -> bool:
     try:
         from IPython import get_ipython
+
         shell = get_ipython()
         return shell is not None and shell.__class__.__name__ == "ZMQInteractiveShell"
     except Exception:
         return False
+
 
 if _in_jupyter():
     print(f"\n🎉 xrheed v{__version__} loaded!")

--- a/src/xrheed/loaders.py
+++ b/src/xrheed/loaders.py
@@ -1,185 +1,144 @@
 """
-RHEED Data Loaders
+RHEED Data Loader
 
-This module provides functions to load RHEED images from files using registered plugins.
+Provides a unified API to load RHEED images either via plugins or manually.
 """
 
 import logging
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Union, Sequence, cast
 
 import numpy as np
 import xarray as xr
 from numpy.typing import NDArray
 from PIL import Image
 
-from .plugins import load_single_image
+from .plugins import PLUGINS
 
-__all__ = ["load_data", "load_data_manual"]
+CANONICAL_STACK_DIMS = {"alpha", "beta", "coverage", "time", "temperature"}
+
+__all__ = ["load_data"]
 
 logger = logging.getLogger(__name__)
 
 
 def load_data(
-    path: Union[str, Path],
-    plugin: str,
-    **kwargs,
-) -> xr.DataArray:
-    """
-    Load a single RHEED image using the specified plugin.
-
-    Parameters
-    ----------
-    path : str or Path
-        Path to the file containing RHEED data.
-    plugin : str
-        Name of the plugin to use for loading.
-    **kwargs : dict
-        Additional arguments passed to the plugin loader.
-
-    Returns
-    -------
-    xr.DataArray
-        The loaded RHEED image.
-
-    Raises
-    ------
-    ValueError
-        If the path is invalid or does not exist.
-    NotImplementedError
-        If the path is a directory (directory loading not yet implemented).
-    """
-    if not path:
-        raise ValueError("You must provide a valid path.")
-
-    path = Path(path).absolute()
-    logger.info(f"Loading data from: {path}")
-    logger.debug(f"Using plugin: {plugin}")
-
-    if path.is_file():
-        logger.info(f"Detected file: {path}")
-        return load_single_image(path, plugin, **kwargs)
-
-    elif path.is_dir():
-        logger.warning(f"Directory loading is not implemented yet: {path}")
-        raise NotImplementedError(
-            "Loading data from directories is not implemented yet."
-        )
-
-    else:
-        logger.error(f"Path does not exist: {path}")
-        raise ValueError(f"The specified path does not exist: {path}")
-
-
-def load_data_manual(
-    path: Union[str, Path],
+    path: Union[str, Path, Sequence[Union[str, Path]]],
+    plugin: Optional[str] = None,
     *,
-    screen_sample_distance: float,
-    screen_scale: float,
-    beam_energy: float,
+    screen_sample_distance: Optional[float] = None,
+    screen_scale: Optional[float] = None,
+    beam_energy: Optional[float] = None,
     screen_center_sx_px: Optional[int] = None,
     screen_center_sy_px: Optional[int] = None,
     alpha: float = 0.0,
     beta: float = 2.0,
+    stack_dim: Optional[str] = None,
+    stack_coords: Optional[Sequence[float]] = None,
+    **kwargs,
 ) -> xr.DataArray:
     """
-    Manually load a RHEED image without using a plugin.
-
-    This is the fallback loader for cases where no plugin is available.
-    The user must provide the essential parameters.
+    Load a RHEED image (or a stack of images) using either a plugin or manual parameters.
 
     Parameters
     ----------
-    path : str | Path
-        Path to the image file (BMP, PNG, TIFF, etc.).
-    screen_sample_distance : float
-        Distance from sample to screen [mm].
-    screen_scale : float
-        Scaling factor [pixels per mm].
-    beam_energy : float
-        Beam energy [eV].
-    screen_center_sx_px : int, optional
-        Horizontal center of the image in pixels.
-        Defaults to image midpoint if not provided.
-    screen_center_sy_px : int, optional
-        Vertical center of the image in pixels.
-        Defaults to image midpoint if not provided.
-    alpha : float, optional
-        Azimuthal angle, by default 0.0.
-    beta : float, optional
-        Incident angle, by default 2.0.
+    path : str | Path | list[str|Path]
+        File path (single image) or list of files (stacked images).
+    plugin : str, optional
+        Name of plugin to use. If None, manual mode is assumed.
+    screen_sample_distance, screen_scale, beam_energy : float
+        Required in manual mode.
+    screen_center_sx_px, screen_center_sy_px : int, optional
+        Optional centers in px (default: image midpoints).
+    alpha, beta : float
+        Optional angles.
+    stack_dim : str, optional
+        New dimension name when stacking multiple files.
+    stack_coords : array-like, optional
+        Coordinates for the new dimension.
 
     Returns
     -------
     xarray.DataArray
-        Image data with physical coordinates and attributes.
-
-    Raises
-    ------
-    ValueError
-        If any of the required calibration parameters are missing.
+        Image data with coordinates and attributes.
     """
+
+    # --- Multi-file case ---
+    if isinstance(path, (list, tuple)):
+        print("This is not fully implemented now!")
+
+        if plugin is None:
+            raise ValueError("Multi-file loading is only supported with plugins.")
+        logger.info(f"Loading {len(path)} files with plugin={plugin}")
+        arrays = [load_data(p, plugin=plugin, **kwargs) for p in path]
+
+        if stack_dim is None:
+            raise ValueError("stack_dim must be provided when loading multiple files.")
+
+        if stack_dim not in CANONICAL_STACK_DIMS:
+            logger.warning(
+                f"Non-standard stack dimension '{stack_dim}'. "
+                f"Consider using one of {sorted(CANONICAL_STACK_DIMS)} for consistency."
+            )
+
+        da = xr.concat(arrays, dim=stack_dim)
+        if stack_coords is not None:
+            da = da.assign_coords({stack_dim: stack_coords})
+        return da
+
+    # --- Single-file case ---
+    path = cast(str | Path, path)
     path = Path(path)
 
-    # Ensure required parameters are present
-    for key, val in {
-        "screen_sample_distance": screen_sample_distance,
-        "screen_scale": screen_scale,
-        "beam_energy": beam_energy,
-    }.items():
-        if val is None:
-            raise ValueError(f"Missing required parameter: '{key}'")
+    if plugin is not None:
+        plugin_cls = PLUGINS[plugin]
+        plugin_instance = plugin_cls()
+        if not plugin_instance.is_file_accepted(path):
+            raise ValueError(
+                f"File {path} not accepted by plugin '{plugin}'. "
+                f"Allowed extensions: {plugin_cls.TOLERATED_EXTENSIONS}"
+            )
+        return plugin_instance.load_single_image(path, **kwargs)
 
-    # Load image using Pillow (convert to grayscale, ensure np.uint8)
-    try:
+    # --- Single-file case - manual mode ---
+    else:
+    
+        assert screen_scale is not None, "screen_scale must be provided in manual mode"
+        assert (
+            screen_sample_distance is not None
+        ), "screen_scale must be provided in manual mode"
+        assert beam_energy is not None, "screen_scale must be provided in manual mode"
+
+        # Load image (bmp/png/tiff/…)
         image = Image.open(path).convert("L")
-    except Exception as e:
-        raise ValueError(f"Cannot load image file '{path}': {e}")
+        image_np: NDArray[np.uint8] = np.array(image, dtype=np.uint8)
 
-    image_np: NDArray[np.uint8] = np.array(image, dtype=np.uint8)
+        h: int
+        w: int
+        h, w = image_np.shape
 
-    height: int
-    width: int
-    height, width = image_np.shape
+        if screen_center_sx_px is None:
+            screen_center_sx_px = w // 2
+        if screen_center_sy_px is None:
+            screen_center_sy_px = h // 2
 
-    # Default centers if not given
-    if screen_center_sx_px is None:
-        screen_center_sx_px = width // 2
-    if screen_center_sy_px is None:
-        screen_center_sy_px = height // 2
+        sx = (np.arange(w) - screen_center_sx_px) / screen_scale
+        sy = (screen_center_sy_px - np.arange(h)) / screen_scale
 
-    # Coordinates in mm
-    sx_coords: NDArray[np.float64] = (
-        np.arange(width, dtype=np.float64) - screen_center_sx_px
-    ) / screen_scale
-    sy_coords: NDArray[np.float64] = (
-        screen_center_sy_px - np.arange(height, dtype=np.float64)
-    ) / screen_scale
+        sy = np.flip(sy)
+        image_np = np.flipud(image_np)
 
-    # Flip vertically to match coordinate orientation
-    sy_coords = np.flip(sy_coords)
-    image_np = np.flipud(image_np)
+        coords = {"sy": sy, "sx": sx}
+        attrs = dict(
+            plugin="manual",
+            screen_sample_distance=screen_sample_distance,
+            screen_scale=screen_scale,
+            screen_center_sx_px=screen_center_sx_px,
+            screen_center_sy_px=screen_center_sy_px,
+            beam_energy=beam_energy,
+            alpha=alpha,
+            beta=beta,
+            file_name=path.name,
+        )
 
-    coords: dict[str, NDArray[np.floating]] = {
-        "sy": sy_coords,
-        "sx": sx_coords,
-    }
-    dims = ["sy", "sx"]
-
-    attrs: dict[str, float | str] = {
-        "plugin": "manual",
-        "screen_sample_distance": screen_sample_distance,
-        "screen_scale": screen_scale,
-        "screen_center_sx_px": screen_center_sx_px,
-        "screen_center_sy_px": screen_center_sy_px,
-        "beam_energy": beam_energy,
-        "alpha": alpha,
-        "beta": beta,
-    }
-
-    return xr.DataArray(
-        data=image_np,
-        coords=coords,
-        dims=dims,
-        attrs=attrs,
-    )
+        return xr.DataArray(image_np, coords=coords, dims=["sy", "sx"], attrs=attrs)

--- a/src/xrheed/loaders.py
+++ b/src/xrheed/loaders.py
@@ -6,7 +6,7 @@ Provides a unified API to load RHEED images either via plugins or manually.
 
 import logging
 from pathlib import Path
-from typing import Optional, Union, Sequence, cast
+from typing import Optional, Sequence, Union, cast
 
 import numpy as np
 import xarray as xr
@@ -102,7 +102,6 @@ def load_data(
 
     # --- Single-file case - manual mode ---
     else:
-    
         assert screen_scale is not None, "screen_scale must be provided in manual mode"
         assert (
             screen_sample_distance is not None

--- a/src/xrheed/plugins/__init__.py
+++ b/src/xrheed/plugins/__init__.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Set, Type, Optional
 
 import numpy as np
 import xarray as xr
+import datetime
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +45,8 @@ class LoadRheedBase(abc.ABC):
         """Attach common metadata (file name, creation time) to attrs."""
         da.attrs["file_name"] = file_path.name
         try:
-            da.attrs["file_ctime"] = Path(file_path).stat().st_birthtime
+            ctime = Path(file_path).stat().st_birthtime
+            da.attrs["file_ctime"] = datetime.datetime.fromtimestamp(ctime).strftime("%Y-%m-%d, %H:%M:%S")
         except Exception:
             pass
         return da

--- a/src/xrheed/plugins/__init__.py
+++ b/src/xrheed/plugins/__init__.py
@@ -3,13 +3,13 @@ Plugin system for RHEED data loading.
 """
 
 import abc
+import datetime
 import logging
 from pathlib import Path
-from typing import Any, Dict, Set, Type, Optional
+from typing import Any, Dict, Optional, Set, Type
 
 import numpy as np
 import xarray as xr
-import datetime
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +46,9 @@ class LoadRheedBase(abc.ABC):
         da.attrs["file_name"] = file_path.name
         try:
             ctime = Path(file_path).stat().st_birthtime
-            da.attrs["file_ctime"] = datetime.datetime.fromtimestamp(ctime).strftime("%Y-%m-%d, %H:%M:%S")
+            da.attrs["file_ctime"] = datetime.datetime.fromtimestamp(ctime).strftime(
+                "%Y-%m-%d, %H:%M:%S"
+            )
         except Exception:
             pass
         return da

--- a/src/xrheed/plugins/__init__.py
+++ b/src/xrheed/plugins/__init__.py
@@ -1,118 +1,75 @@
 """
-Submodule `plugins` provides tools RHEED image loading.
+Plugin system for RHEED data loading.
 """
 
-from abc import ABC, abstractmethod
+import abc
+import logging
 from pathlib import Path
-from typing import ClassVar, Dict, List, Type
+from typing import Any, Dict, Set, Type, Optional
 
+import numpy as np
 import xarray as xr
 
-__all__ = ["LoadRheedBase", "load_single_image", "load_many_images", "rheed_plugin"]
+logger = logging.getLogger(__name__)
+
+PLUGINS: Dict[str, Type["LoadRheedBase"]] = {}
 
 
-# -----------------------------
-# Abstract Base Class
-# -----------------------------
-class LoadRheedBase(ABC):
-    """Abstract base class for RHEED data loader plugins."""
+def register_plugin(name: str):
+    """Decorator to register a new plugin."""
 
-    # File extensions this plugin can handle
-    TOLERATED_EXTENSIONS: ClassVar[set[str]] = set()
-
-    # Central registry: plugin name -> plugin class
-    PLUGINS: ClassVar[Dict[str, Type["LoadRheedBase"]]] = {}
-
-    # Attribute keys required in every plugin
-    REQUIRED_ATTR_KEYS: ClassVar[set[str]] = {
-        "plugin",
-        "screen_sample_distance",
-        "screen_scale",
-        "beam_energy",
-    }
-
-    def __init_subclass__(cls, **kwargs):
-        super().__init_subclass__(**kwargs)
-
-        # Validate ATTRS
-        attrs = getattr(cls, "ATTRS", None)
-        if not isinstance(attrs, dict):
-            raise TypeError(f"{cls.__name__} must define ATTRS as a dictionary.")
-
-        missing = cls.REQUIRED_ATTR_KEYS - attrs.keys()
-        if missing:
-            raise ValueError(
-                f"{cls.__name__} is missing required ATTRS keys: {missing}"
-            )
-
-    @classmethod
-    def register_plugin(cls, name: str, plugin_cls: Type["LoadRheedBase"]):
-        """Register a plugin class under a given name."""
-        if not issubclass(plugin_cls, LoadRheedBase):
-            raise TypeError(f"{plugin_cls} must inherit from LoadRheedBase")
-        cls.PLUGINS[name] = plugin_cls
-
-    @classmethod
-    def get_plugin(cls, name: str) -> Type["LoadRheedBase"]:
-        """Retrieve a plugin class by name."""
-        if name not in cls.PLUGINS:
-            raise ValueError(f"Plugin '{name}' is not registered")
-        return cls.PLUGINS[name]
-
-    @classmethod
-    def find_plugin_by_extension(cls, ext: str) -> List[Type["LoadRheedBase"]]:
-        """Return all plugin classes that can handle a given file extension."""
-        ext = ext.lower()
-        return [p for p in cls.PLUGINS.values() if ext in p.TOLERATED_EXTENSIONS]
-
-    @classmethod
-    def is_file_accepted(cls, file: str | Path) -> bool:
-        """Determine whether this loader can handle the file."""
-        p = Path(file)
-        if not p.exists() or not p.is_file():
-            return False
-        return p.suffix.lower() in (ext.lower() for ext in cls.TOLERATED_EXTENSIONS)
-
-    @abstractmethod
-    def load_single_image(self, file_path: Path, **kwargs) -> xr.DataArray:
-        """Load a single RHEED image. Must be implemented by subclasses."""
-        pass
-
-
-# -----------------------------
-# Decorator for Plugin Registration
-# -----------------------------
-def rheed_plugin(name: str):
-    """
-    Decorator to automatically register a RHEED plugin class.
-
-    Usage:
-        @rheed_plugin("plugin_name")
-        class LoadPlugin(LoadRheedBase):
-            ...
-    """
-
-    def wrapper(cls):
-        LoadRheedBase.register_plugin(name, cls)
+    def decorator(cls):
+        PLUGINS[name] = cls
+        logger.info(f"Registered RHEED plugin: {name}")
         return cls
 
-    return wrapper
+    return decorator
 
 
-# -----------------------------
-# Utility Functions
-# -----------------------------
-def load_single_image(image_path: Path, plugin_name: str, **kwargs) -> xr.DataArray:
-    """Load a single image using the specified plugin."""
-    plugin_cls = LoadRheedBase.get_plugin(plugin_name)
-    plugin_instance = plugin_cls()
-    return plugin_instance.load_single_image(image_path, **kwargs)
+class LoadRheedBase(abc.ABC):
+    """
+    Base class for RHEED plugins.
+    """
 
+    TOLERATED_EXTENSIONS: Set[str] = set()
+    ATTRS: Dict[str, Any] = {}
 
-def load_many_images(
-    image_paths: list[Path], plugin_name: str, **kwargs
-) -> list[xr.DataArray]:
-    """Load multiple images using the specified plugin."""
-    plugin_cls = LoadRheedBase.get_plugin(plugin_name)
-    plugin_instance = plugin_cls()
-    return [plugin_instance.load_single_image(p, **kwargs) for p in image_paths]
+    def is_file_accepted(self, file_path: Path) -> bool:
+        return file_path.suffix.lower() in self.TOLERATED_EXTENSIONS
+
+    @abc.abstractmethod
+    def load_single_image(self, file_path: Path, **kwargs) -> xr.DataArray: ...
+
+    def add_file_metadata(self, da: xr.DataArray, file_path: Path) -> xr.DataArray:
+        """Attach common metadata (file name, creation time) to attrs."""
+        da.attrs["file_name"] = file_path.name
+        try:
+            da.attrs["file_ctime"] = Path(file_path).stat().st_birthtime
+        except Exception:
+            pass
+        return da
+
+    def dataarray_from_image(
+        self,
+        image_np: np.ndarray,
+        attrs_override: Optional[Dict[str, Any]] = None,
+        flip: bool = True,
+    ) -> xr.DataArray:
+        """
+        Helper to create DataArray from a numpy image, using ATTRS scaling and centers.
+        Plugins may use or override this.
+        """
+        px_to_mm = float(self.ATTRS["screen_scale"])
+        h, w = image_np.shape
+
+        sx = (np.arange(w) - self.ATTRS.get("screen_center_sx_px", w // 2)) / px_to_mm
+        sy = (self.ATTRS.get("screen_center_sy_px", h // 2) - np.arange(h)) / px_to_mm
+
+        if flip:
+            sy = np.flip(sy)
+            image_np = np.flipud(image_np)
+
+        coords = {"sy": sy, "sx": sx}
+        attrs = {**self.ATTRS, **(attrs_override or {})}
+
+        return xr.DataArray(image_np, coords=coords, dims=["sy", "sx"], attrs=attrs)

--- a/src/xrheed/plugins/dsnp_arpes_bmp.py
+++ b/src/xrheed/plugins/dsnp_arpes_bmp.py
@@ -1,24 +1,20 @@
-import logging
 from pathlib import Path
-from typing import ClassVar
 
 import numpy as np
 import xarray as xr
 from numpy.typing import NDArray
 from PIL import Image
 
-from xrheed.plugins import LoadRheedBase, rheed_plugin
-
-logger = logging.getLogger(__name__)
+from . import LoadRheedBase, register_plugin
 
 
-@rheed_plugin("dsnp_arpes_bmp")
-class LoadPlugin(LoadRheedBase):
+@register_plugin("dsnp_arpes_bmp")
+class DsnpArpesBmpPlugin(LoadRheedBase):
     """Plugin to load UMCS DSNP ARPES BMP RHEED images."""
 
-    TOLERATED_EXTENSIONS: ClassVar[set[str]] = {".bmp"}
+    TOLERATED_EXTENSIONS = {".bmp"}
 
-    ATTRS: ClassVar[dict[str, float | str]] = {
+    ATTRS = {
         "plugin": "UMCS DSNP ARPES bmp",
         "screen_sample_distance": 309.2,  # mm
         "screen_scale": 9.04,  # pixels per mm
@@ -29,55 +25,11 @@ class LoadPlugin(LoadRheedBase):
         "beta": 2.0,  # incident angle
     }
 
-    def load_single_image(
-        self,
-        file_path: Path | str,
-        plugin_name: str = "",
-        **kwargs,
-    ) -> xr.DataArray:
-        file_path = Path(file_path)
-
-        if not self.is_file_accepted(file_path):
-            raise ValueError(f"File not accepted: {file_path}")
-
-        px_to_mm = float(self.ATTRS["screen_scale"])
-
-        # Load BMP image using Pillow
+    def load_single_image(self, file_path: Path, **kwargs) -> xr.DataArray:
+        # Load BMP image using Pillow and convert to numpy array
         image = Image.open(file_path).convert("L")  # Convert to grayscale
         image_np: NDArray[np.uint8] = np.array(image)
 
-        height: int
-        width: int
-        height, width = image_np.shape
+        da = self.dataarray_from_image(image_np)
 
-        # Generate coordinates
-        sx_coords: NDArray[np.float64] = np.arange(width, dtype=np.float64)
-        sy_coords: NDArray[np.float64] = np.arange(height, dtype=np.float64)
-
-        # Shift coordinates to center
-        sx_coords -= float(self.ATTRS["screen_center_sx_px"])
-        sy_coords = float(self.ATTRS["screen_center_sy_px"]) - sy_coords
-        # Convert from pixels to mm
-        sx_coords /= px_to_mm
-        sy_coords /= px_to_mm
-
-        # Flip vertically to match new y coordinates
-        sy_coords = np.flip(sy_coords)
-        image_np = np.flipud(image_np)
-
-        coords: dict[str, NDArray[np.floating]] = {
-            "sy": sy_coords,
-            "sx": sx_coords,
-        }
-        dims = ["sy", "sx"]
-
-        attrs = self.ATTRS.copy()
-
-        logger.info(f"Loaded BMP image {file_path} with shape {image_np.shape}")
-
-        return xr.DataArray(
-            data=image_np,
-            coords=coords,
-            dims=dims,
-            attrs=attrs,
-        )
+        return self.add_file_metadata(da, file_path)

--- a/src/xrheed/plugins/dsnp_arpes_raw.py
+++ b/src/xrheed/plugins/dsnp_arpes_raw.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 import numpy as np
 import xarray as xr
 

--- a/src/xrheed/plugins/dsnp_arpes_raw.py
+++ b/src/xrheed/plugins/dsnp_arpes_raw.py
@@ -1,112 +1,31 @@
-import logging
 from pathlib import Path
-from typing import ClassVar
-
 import numpy as np
 import xarray as xr
-from numpy.typing import NDArray
 
-from xrheed.plugins import LoadRheedBase, rheed_plugin
-
-logger = logging.getLogger(__name__)
+from . import LoadRheedBase, register_plugin
 
 
-@rheed_plugin("dsnp_arpes_raw")
-class LoadPlugin(LoadRheedBase):
-    """Plugin to load UMCS DSNP ARPES raw RHEED images."""
+@register_plugin("dsnp_arpes_raw")
+class DsnpArpesRawPlugin(LoadRheedBase):
+    """Plugin to load UMCS DSNP ARPES RAW RHEED images."""
 
-    TOLERATED_EXTENSIONS: ClassVar[set[str]] = {".raw"}
+    TOLERATED_EXTENSIONS = {".raw"}
 
-    ATTRS: ClassVar[dict[str, float | str]] = {
+    ATTRS = {
         "plugin": "UMCS DSNP ARPES raw",
         "screen_sample_distance": 309.2,  # mm
         "screen_scale": 9.04,  # pixels per mm
-        "screen_center_sx_px": 740,  # horizontal center of an image in px
-        "screen_center_sy_px": 155,  # vertical center (shadow edge) in px
-        "beam_energy": 18.6 * 1000,  # eV
-        "alpha": 0.0,  # azimuthal angle
-        "beta": 2.0,  # incident angle
+        "screen_center_sx_px": 740,
+        "screen_center_sy_px": 155,
+        "beam_energy": 18_6000,  # eV
+        "alpha": 0.0,
+        "beta": 2.0,
     }
 
-    def load_single_image(
-        self,
-        file_path: Path | str,
-        plugin_name: str = "",
-        **kwargs,
-    ) -> xr.DataArray:
-        """
-        Load a single RHEED image from a raw binary file.
+    def load_single_image(self, file_path: Path, **kwargs) -> xr.DataArray:
+        # Load image data into numpy
+        raw = np.fromfile(file_path, dtype=">u2").reshape(1038, 1388)
+        image_np = (raw / 256).astype(np.uint8)
 
-        Parameters
-        ----------
-        file_path : Path or str
-            Path to the raw RHEED image file.
-        plugin_name : str
-            Plugin name (unused here, for compatibility with base class).
-        **kwargs
-            Additional arguments:
-            - image_size: optional list [height, width] for non-standard image dimensions.
-
-        Returns
-        -------
-        xr.DataArray
-            The loaded RHEED image as an xarray DataArray with proper coordinates and attributes.
-        """
-        file_path = Path(file_path)
-
-        if not self.is_file_accepted(file_path):
-            raise ValueError(f"File not accepted: {file_path}")
-
-        px_to_mm = float(self.ATTRS["screen_scale"])
-
-        # Allow custom image size via kwargs
-        image_size = kwargs.get("image_size", [1038, 1388])
-
-        height: int
-        width: int
-        height, width = image_size
-
-        # Load raw data
-        with file_path.open("rb") as file:
-            image_16bit: NDArray[np.uint16] = np.fromfile(file, dtype=">u2").reshape(
-                *image_size
-            )
-
-        # Convert to 8-bit for memory efficiency
-        image: NDArray[np.uint8] = (image_16bit / 256).astype(np.uint8)
-
-        # Generate coordinates
-        sx_coords: NDArray[np.float64] = np.arange(width, dtype=np.float64)
-        sy_coords: NDArray[np.float64] = np.arange(height, dtype=np.float64)
-
-        # Shift coordinates to center
-        sx_coords -= float(self.ATTRS["screen_center_sx_px"])
-        sy_coords = float(self.ATTRS["screen_center_sy_px"]) - sy_coords
-
-        # Convert from pixels to mm
-        sx_coords /= px_to_mm
-        sy_coords /= px_to_mm
-
-        # Flip vertically to match new y coordinates
-        sy_coords = np.flip(sy_coords)
-        image = np.flipud(image)
-
-        coords: dict[str, NDArray[np.floating]] = {
-            "sy": sy_coords,
-            "sx": sx_coords,
-        }
-        dims = ["sy", "sx"]
-        attrs = self.ATTRS.copy()  # Copy to avoid modifying the class-level dictionary
-
-        # Log the loading
-        logger.info(f"Loaded image {file_path} with shape {image.shape}")
-
-        # Create xarray DataArray
-        data_array = xr.DataArray(
-            data=image,
-            coords=coords,
-            dims=dims,
-            attrs=attrs,
-        )
-
-        return data_array
+        da = self.dataarray_from_image(image_np)
+        return self.add_file_metadata(da, file_path)

--- a/src/xrheed/xarray_accessors.py
+++ b/src/xrheed/xarray_accessors.py
@@ -101,22 +101,25 @@ class RHEEDAccessor:
     def __repr__(self) -> str:
         """
         Return a human-readable summary of the DataArray and key RHEED metadata.
-        Missing attributes are shown as 'N/A'.
         """
         screen_scale = self._get_attr("screen_scale", None)
         beam_energy = self._get_attr("beam_energy", None)
         screen_sample_distance = self._get_attr("screen_sample_distance", None)
         beta = self._get_attr("beta", DEFAULT_BETA)
         alpha = self._get_attr("alpha", DEFAULT_ALPHA)
+        file_name = self._obj.attrs.get("file_name", "N/A")
+        file_ctime = self._obj.attrs.get("file_ctime", "N/A")
 
         return (
             f"<RHEEDAccessor>\n"
+            f"  File name: {file_name}\n"
+            f"  File creation time: {file_ctime}\n"
             f"  Image shape: {self._obj.shape}\n"
-            f"  Screen scale: {screen_scale if screen_scale is not None else 'N/A'}\n"
-            f"  Screen sample distance: {screen_sample_distance if screen_sample_distance is not None else 'N/A'}\n"
+            f"  Screen scale: {screen_scale} px/mm\n"
+            f"  Screen sample distance: {screen_sample_distance} mm\n"
             f"  Beta (incident) angle: {beta:.2f} deg\n"
             f"  Alpha (azimuthal) angle: {alpha:.2f} deg\n"
-            f"  Beam Energy: {beam_energy if beam_energy is not None else 'N/A'} eV\n"
+            f"  Beam Energy: {beam_energy} eV\n"
         )
 
     @property

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -3,14 +3,15 @@ from pathlib import Path
 
 import numpy as np
 import xarray as xr
+import xrheed
 from xrheed.conversion import base, image
-from xrheed.loaders import load_data
+
 
 
 class TestBaseConversion(unittest.TestCase):
     def setUp(self):
         test_data_path = Path(__file__).parent / "data" / "Si_111_7x7_112_phi_00.raw"
-        self.rheed_image = load_data(test_data_path, plugin="dsnp_arpes_raw")
+        self.rheed_image = xrheed.load_data(test_data_path, plugin="dsnp_arpes_raw")
 
     def test_convert_sx_to_ky(self):
         sx_coords_mm = np.array([0, 10, 20])

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -3,9 +3,9 @@ from pathlib import Path
 
 import numpy as np
 import xarray as xr
+
 import xrheed
 from xrheed.conversion import base, image
-
 
 
 class TestBaseConversion(unittest.TestCase):

--- a/tests/test_data_loading.py
+++ b/tests/test_data_loading.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import numpy as np
 import xarray as xr
+
 import xrheed
 
 

--- a/tests/test_data_loading.py
+++ b/tests/test_data_loading.py
@@ -36,6 +36,16 @@ class TestDataLoading(unittest.TestCase):
                         (float, int),
                         msg=f"[{plugin}] {attr} is not a number",
                     )
+                # Check 'fname' attribute exists and matches the file path
+                file_name = self.plugin_file_map[plugin]
+                self.assertIn(
+                    "file_name", attrs, msg=f"[{plugin}] Missing 'file_name' attribute"
+                )
+                self.assertEqual(
+                    attrs["file_name"],
+                    file_name,
+                    msg=f"[{plugin}] 'file_name' attribute does not real file name",
+                )
 
     def test_dataarray_structure(self):
         for plugin, image in self.loaded_images.items():

--- a/tests/test_data_loading.py
+++ b/tests/test_data_loading.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import numpy as np
 import xarray as xr
-from xrheed.loaders import load_data, load_data_manual
+import xrheed
 
 
 class TestDataLoading(unittest.TestCase):
@@ -19,7 +19,7 @@ class TestDataLoading(unittest.TestCase):
         self.loaded_images = {}
         for plugin, filename in self.plugin_file_map.items():
             file_path = Path(__file__).parent / "data" / filename
-            self.loaded_images[plugin] = load_data(file_path, plugin=plugin)
+            self.loaded_images[plugin] = xrheed.load_data(file_path, plugin=plugin)
 
     def test_plugin_attributes(self):
         required_attrs = ["screen_scale", "beam_energy", "screen_sample_distance"]
@@ -94,7 +94,7 @@ class TestDataLoading(unittest.TestCase):
         file_path = Path(__file__).parent / "data" / self.manual_load_file
 
         # Provide required manual parameters
-        da_manual = load_data_manual(
+        da_manual = xrheed.load_data(
             file_path,
             screen_sample_distance=309.2,
             screen_scale=9.04,

--- a/tests/test_ewald.py
+++ b/tests/test_ewald.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import numpy as np
 import xarray as xr
-from xrheed.loaders import load_data
+import xrheed
 from xrheed.kinematics.ewald import Ewald
 from xrheed.kinematics.lattice import Lattice
 
@@ -15,7 +15,7 @@ class TestEwald(unittest.TestCase):
 
         # Prepare test image
         test_data_path = Path(__file__).parent / "data" / "Si_111_7x7_112_phi_00.raw"
-        self.rheed_image = load_data(test_data_path, plugin="dsnp_arpes_raw")
+        self.rheed_image = xrheed.load_data(test_data_path, plugin="dsnp_arpes_raw")
         self.rheed_image.ri.apply_image_center(auto_center=True)
         self.rheed_image.ri.beta = 2.8
 

--- a/tests/test_ewald.py
+++ b/tests/test_ewald.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import numpy as np
 import xarray as xr
+
 import xrheed
 from xrheed.kinematics.ewald import Ewald
 from xrheed.kinematics.lattice import Lattice

--- a/tests/test_lattice.py
+++ b/tests/test_lattice.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy as np
+
 from xrheed.kinematics.lattice import Lattice, rotation_matrix
 
 

--- a/tests/test_preparation.py
+++ b/tests/test_preparation.py
@@ -5,14 +5,14 @@ import matplotlib
 
 matplotlib.use("Agg")
 
-from xrheed.loaders import load_data
+import xrheed
 from xrheed.preparation.alignment import find_horizontal_center, find_vertical_center
 
 
 class TestDataLoading(unittest.TestCase):
     def setUp(self):
         test_data_path = Path(__file__).parent / "data" / "Si_111_7x7_112_phi_00.raw"
-        self.rheed_image = load_data(test_data_path, plugin="dsnp_arpes_raw")
+        self.rheed_image = xrheed.load_data(test_data_path, plugin="dsnp_arpes_raw")
 
     def test_set_center(self):
         center_x = -0.5

--- a/tests/test_preparation.py
+++ b/tests/test_preparation.py
@@ -6,7 +6,8 @@ import matplotlib
 matplotlib.use("Agg")
 
 import xrheed
-from xrheed.preparation.alignment import find_horizontal_center, find_vertical_center
+from xrheed.preparation.alignment import (find_horizontal_center,
+                                          find_vertical_center)
 
 
 class TestDataLoading(unittest.TestCase):


### PR DESCRIPTION
This PR introduces a major upgrade to the data loading and plugin system of `xrheed`. The system is now more streamlined and better organized. Plugins are now easier to write and maintain, as they typically only need to provide experiment geometry as attributes and load an image into a numpy array.

Helper functions will handle the conversion to a `DataArray` and add additional metadata as attributes.

From the user's perspective, the only change is the removal of `load_data_manual()`. Manual loading is now handled by the same `load_data()` function when the plugin keyword argument is not provided, and instead, the required parameters are passed.

**⚠️ Breaking Change Warning**
The removal of `load_data_manual()` may affect existing workflows or scripts that rely on it. Users should update their code to use `load_data()` with explicit parameters instead. Please review your usage to ensure compatibility.

Closes #31